### PR TITLE
fix: remove redundant type annotations in SrpPassword.set_encrypt_info

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -70,9 +70,9 @@ class SrpPassword:
 
     def set_encrypt_info(self, salt: bytes, iterations: int, key_length: int) -> None:
         """Set encrypt info."""
-        self.salt: bytes = salt
-        self.iterations: int = iterations
-        self.key_length: int = key_length
+        self.salt = salt
+        self.iterations = iterations
+        self.key_length = key_length
 
     def encode(self) -> bytes:
         """Encode password."""


### PR DESCRIPTION
Resolves basedpyright reportRedeclaration warnings by removing duplicate type annotations from instance variable assignments in the SrpPassword class. Changes: Removed redundant type annotations from self.salt, self.iterations, and self.key_length assignments in set_encrypt_info method. Type information is already properly declared in __init__ method. Follows Python typing best practices per PEP 526. Testing: All pre-commit hooks pass, no functional changes, type checking preserved. Fixes the three basedpyright reportRedeclaration warnings.